### PR TITLE
Add converter as an alias of openapi attribute

### DIFF
--- a/apispec_oneofschema/plugin.py
+++ b/apispec_oneofschema/plugin.py
@@ -60,3 +60,4 @@ class MarshmallowPlugin(marshmallow.MarshmallowPlugin):
             schema_name_resolver=self.schema_name_resolver,
             spec=spec,
         )
+        self.converter = self.openapi # Fix for the openapi attribute being renamed in apispec 3.0.0


### PR DESCRIPTION
Closes #5 

Adds an alias of the `openapi` attribute to `converter` for apispec >= 3.0.0.