### PR TITLE
Adjusts plugin to match apispec 3.3 api

### DIFF
--- a/apispec_oneofschema/plugin.py
+++ b/apispec_oneofschema/plugin.py
@@ -53,11 +53,4 @@ def is_oneof(schema):
 
 
 class MarshmallowPlugin(marshmallow.MarshmallowPlugin):
-    def init_spec(self, spec):
-        super(MarshmallowPlugin, self).init_spec(spec)
-        self.openapi = OneofOpenAPIConverter(
-            openapi_version=spec.openapi_version,
-            schema_name_resolver=self.schema_name_resolver,
-            spec=spec,
-        )
-        self.converter = self.openapi # Fix for the openapi attribute being renamed in apispec 3.0.0
+    Converter = OneofOpenAPIConverter


### PR DESCRIPTION
This pull request fixes an issue with the updated api of the apispec's `MarshmallowPlugin`. Instead of overriding the `init` method the plugin can simply change the `Converter` class attribute from the default `OpenApiConverter` to `OneofOpenApiConverter` and let the base class handle the rest.

Fixes #8