### PR TITLE
Allow marshmallow 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='apispec-oneofschema',
       url='https://github.com/timakro/apispec-oneofschema',
       install_requires=[
           'apispec>=3.0.0',
-          'marshmallow<4.0.0',
+          'marshmallow<5.0.0',
           'marshmallow-oneofschema'
           ],
       py_modules=['apispec_oneofschema.plugin']


### PR DESCRIPTION
I've run pytest on the existing tests with marshmallow 4.0.0 installed and they all passed, so hopefully there's no more changes needed to be made for this library to work there 🙂 